### PR TITLE
Replace mb_convert_encoding

### DIFF
--- a/Abfall_IO/module.php
+++ b/Abfall_IO/module.php
@@ -1153,7 +1153,7 @@ class Abfall_IO extends IPSModule
             $dom = new DOMDocument();
             // disable libxml errors
             libxml_use_internal_errors(true);
-            $dom->loadHTML(mb_convert_encoding($response, 'HTML-ENTITIES', 'UTF-8'));
+            $dom->loadHTML(htmlspecialchars_decode(htmlentities($response, ENT_NOQUOTES), ENT_NOQUOTES));
             // remove errors for yucky html
             libxml_clear_errors();
             $xpath = new DOMXpath($dom);

--- a/MuellMax/module.php
+++ b/MuellMax/module.php
@@ -1061,7 +1061,7 @@ class MuellMax extends IPSModule
             $dom = new DOMDocument();
             // disable libxml errors
             libxml_use_internal_errors(true);
-            $dom->loadHTML(mb_convert_encoding($response, 'HTML-ENTITIES', 'UTF-8'));
+            $dom->loadHTML(htmlspecialchars_decode(htmlentities($response, ENT_NOQUOTES), ENT_NOQUOTES));
             // remove errors for yucky html
             libxml_clear_errors();
             $xpath = new DOMXpath($dom);


### PR DESCRIPTION
Using MBString in this context is deprecated in PHP 8.2. See [php.net](https://www.php.net/manual/en/migration82.deprecated.php) and [php.watch](https://php.watch/versions/8.2/mbstring-qprint-base64-uuencode-html-entities-deprecated).